### PR TITLE
[BUGFIX] 마지막 지하철 정류장이 표출되지 않는 현상을 수정합니다.

### DIFF
--- a/Atcha-iOS/Presentation/Location/DetailRoute/DetailRouteInfo/Cell/DetailRouteSubwayCell.swift
+++ b/Atcha-iOS/Presentation/Location/DetailRoute/DetailRouteInfo/Cell/DetailRouteSubwayCell.swift
@@ -61,6 +61,7 @@ final class DetailRouteSubwayCell: UICollectionViewCell {
         super.init(frame: frame)
         setupUI()
         setupConstraints()
+        setupInitialConstraintState()
         setupAction()
     }
     
@@ -105,6 +106,12 @@ final class DetailRouteSubwayCell: UICollectionViewCell {
         stationListStackView.axis = .vertical
         stationListStackView.spacing = 10
         stationListStackView.isHidden = true
+    }
+    
+    private func setupInitialConstraintState() {
+        stationListStackViewTopConstraint?.isActive = false
+        stationListStackViewBottomConstraint?.isActive = false
+        endLabelTopConstraintWithoutStack?.isActive = true // ✅ isExpanded = false 상태
     }
     
     private func setupLineImageView() {


### PR DESCRIPTION
## 📌 관련 이슈
#261 

## ✨ 이슈 내용
- 막차 상세 경로에서, 마지막 지하철 역 정보가 보이지 않습니다.